### PR TITLE
Handle both tensor and numpy input in init_sigmas_for_each_stage

### DIFF
--- a/diffusion_schedulers/scheduling_flow_matching.py
+++ b/diffusion_schedulers/scheduling_flow_matching.py
@@ -142,7 +142,7 @@ class PyramidFlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             timesteps = np.linspace(
                 timestep_max, timestep_min, training_steps + 1,
             )
-            self.timesteps_per_stage[i_s] = torch.from_numpy(timesteps[:-1])
+            self.timesteps_per_stage[i_s] = timesteps[:-1] if isinstance(timesteps, torch.Tensor) else torch.from_numpy(timesteps[:-1])
             stage_sigmas = np.linspace(
                 1, 0, training_steps + 1,
             )


### PR DESCRIPTION
Running this code:
```
from huggingface_hub import snapshot_download
import torch
from PIL import Image
from pyramid_dit import PyramidDiTForVideoGeneration
from diffusers.utils import load_image, export_to_video


model_path = '/home/david/.cache/huggingface/hub/pyramid-flow'   # The local directory to save downloaded checkpoint
snapshot_download("rain1011/pyramid-flow-sd3", local_dir=model_path, local_dir_use_symlinks=False, repo_type='model')


torch.cuda.set_device(0)
model_dtype, torch_dtype = 'bf16', torch.bfloat16   # Use bf16 (not support fp16 yet)

model = PyramidDiTForVideoGeneration(
    '/home/david/.cache/huggingface/hub/pyramid-flow',                                         # The downloaded checkpoint dir
    model_dtype,
    model_variant='diffusion_transformer_768p',     # 'diffusion_transformer_384p'
)

model.vae.to("cuda")
model.dit.to("cuda")
model.text_encoder.to("cuda")
model.vae.enable_tiling()


prompt = "A penguin surffing a sea of bits. 101010101 all over the place."

with torch.no_grad(), torch.cuda.amp.autocast(enabled=True, dtype=torch_dtype):
    frames = model.generate(
        prompt=prompt,
        num_inference_steps=[20, 20, 20],
        video_num_inference_steps=[10, 10, 10],
        height=768,     
        width=1280,
        temp=16,                    # temp=16: 5s, temp=31: 10s
        guidance_scale=9.0,         # The guidance for the first frame, set it to 7 for 384p variant
        video_guidance_scale=5.0,   # The guidance for the other video latent
        output_type="pil",
        save_memory=True,           # If you have enough GPU memory, set it to `False` to improve vae decoding speed
    )

export_to_video(frames, "./text_to_video_sample.mp4", fps=24)
```

I got this error:
```
Fetching 29 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 29/29 [00:00<00:00, 2941.16it/s]
using half precision
Using temporal causal attention
We interp the position embedding of condition latents
You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.05s/it]
The latent dimmension channes is 16
Traceback (most recent call last):
  File "/matrix/david/main_home_folder/myProjects/AI/BIN/Pyramid-Flow/./main.py", line 15, in <module>
    model = PyramidDiTForVideoGeneration(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/matrix/david/main_home_folder/myProjects/AI/BIN/Pyramid-Flow/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py", line 129, in __init__
    self.scheduler = PyramidFlowMatchEulerDiscreteScheduler(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/matrix/david/main_home_folder/myProjects/AI/BIN/Pyramid-Flow/pyenv/lib/python3.11/site-packages/diffusers/configuration_utils.py", line 653, in inner_init
    init(self, *args, **init_kwargs)
  File "/matrix/david/main_home_folder/myProjects/AI/BIN/Pyramid-Flow/diffusion_schedulers/scheduling_flow_matching.py", line 66, in __init__
    self.init_sigmas_for_each_stage()
  File "/matrix/david/main_home_folder/myProjects/AI/BIN/Pyramid-Flow/diffusion_schedulers/scheduling_flow_matching.py", line 146, in init_sigmas_for_each_stage
    self.timesteps_per_stage[i_s] = torch.from_numpy(timesteps[:-1])
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected np.ndarray (got Tensor)
```
This change fixes that. 