### PR TITLE
Specify the spacy version to fix installation issue in python 3.8.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pre-commit
 python-magic
 scikit-image
 sentencepiece
-spacy
+spacy==3.7.5
 streamlit
 timm==0.6.12
 tqdm


### PR DESCRIPTION
I test installation in ubuntu 22.04, python 3.8.10, everything is fine except spacy, the error message as below:

```bash
Downloading https://mirrors.aliyun.com/pypi/packages/07/53/536941af8fbb5cb10a778f0dbd2a17b0f13e7ebfc11e67b154be60508fdf/spacy-3.8.2.tar.gz (1.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/1.3 MB 1.3 MB/s eta 0:00:00
  Installing build dependencies ... error
  error: subprocess-exited-with-error
  
  × pip subprocess to install build dependencies did not run successfully.
  │ exit code: 1
  ╰─> [74 lines of output]
      Looking in indexes: https://mirrors.aliyun.com/pypi/simple/
      Ignoring numpy: markers 'python_version >= "3.9"' don't match your environment
      Collecting setuptools
        Downloading https://mirrors.aliyun.com/pypi/packages/ff/ae/f19306b5a221f6a436d8f2238d5b80925004093fa3edea59835b514d9057/setuptools-75.1.0-py3-none-any.whl (1.2 MB)
           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 2.1 MB/s eta 0:00:00
      Collecting cython<3.0,>=0.25
        Downloading https://mirrors.aliyun.com/pypi/packages/10/46/9a1b428442d09a6496d56e913ff4c3f4a1db119adc45d45ad2655bcb2a68/Cython-0.29.37-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl (1.9 MB)
           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.9/1.9 MB 2.3 MB/s eta 0:00:00
      Collecting cymem<2.1.0,>=2.0.2
        Downloading https://mirrors.aliyun.com/pypi/packages/5f/70/b9945a7918d467c6c7112f6e20176d4f41b89d7ba0b590015b4cb62fb23d/cymem-2.0.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (46 kB)
      Collecting preshed<3.1.0,>=3.0.2
        Downloading https://mirrors.aliyun.com/pypi/packages/aa/7c/f36a498cb114765d0ecec946e6be46d2aadaea19317a1a1828e4aa2383d8/preshed-3.0.9-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (154 kB)
      Collecting murmurhash<1.1.0,>=0.28.0
        Downloading https://mirrors.aliyun.com/pypi/packages/f9/63/49e1eda3c610f49e5d3062e44ed27751f33ca8c4087b100b78b141201a6a/murmurhash-1.0.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (29 kB)
      Collecting thinc<8.4.0,>=8.3.0
        Downloading https://mirrors.aliyun.com/pypi/packages/8a/9f/b2193b69dd112a46800182e897cda2fc9c497dfdd9352a0c5ba9252cf5f0/thinc-8.3.2.tar.gz (193 kB)
        Installing build dependencies: started
        Installing build dependencies: finished with status 'error'
        error: subprocess-exited-with-error
      
        × pip subprocess to install build dependencies did not run successfully.
        │ exit code: 1
        ╰─> [41 lines of output]
            Looking in indexes: https://mirrors.aliyun.com/pypi/simple/
            Ignoring numpy: markers 'python_version >= "3.9"' don't match your environment
            Collecting setuptools
              Using cached https://mirrors.aliyun.com/pypi/packages/ff/ae/f19306b5a221f6a436d8f2238d5b80925004093fa3edea59835b514d9057/setuptools-75.1.0-py3-none-any.whl (1.2 MB)
            Collecting cython<3.0,>=0.25
              Using cached https://mirrors.aliyun.com/pypi/packages/10/46/9a1b428442d09a6496d56e913ff4c3f4a1db119adc45d45ad2655bcb2a68/Cython-0.29.37-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl (1.9 MB)
            Collecting murmurhash<1.1.0,>=1.0.2
              Using cached https://mirrors.aliyun.com/pypi/packages/f9/63/49e1eda3c610f49e5d3062e44ed27751f33ca8c4087b100b78b141201a6a/murmurhash-1.0.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (29 kB)
            Collecting cymem<2.1.0,>=2.0.2
              Using cached https://mirrors.aliyun.com/pypi/packages/5f/70/b9945a7918d467c6c7112f6e20176d4f41b89d7ba0b590015b4cb62fb23d/cymem-2.0.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (46 kB)
            Collecting preshed<3.1.0,>=3.0.2
              Using cached https://mirrors.aliyun.com/pypi/packages/aa/7c/f36a498cb114765d0ecec946e6be46d2aadaea19317a1a1828e4aa2383d8/preshed-3.0.9-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (154 kB)
            Collecting blis<1.1.0,>=1.0.0
              Downloading https://mirrors.aliyun.com/pypi/packages/bd/e4/741f20c9b767330e2605d4c71a775303cb6a9c72764b8802232fe6c7afad/blis-1.0.1.tar.gz (3.6 MB)
                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.6/3.6 MB 1.7 MB/s eta 0:00:00
              Installing build dependencies: started
              Installing build dependencies: finished with status 'error'
              error: subprocess-exited-with-error
      
              × pip subprocess to install build dependencies did not run successfully.
              │ exit code: 1
              ╰─> [9 lines of output]
                  Looking in indexes: https://mirrors.aliyun.com/pypi/simple/
                  Collecting setuptools
                    Using cached https://mirrors.aliyun.com/pypi/packages/ff/ae/f19306b5a221f6a436d8f2238d5b80925004093fa3edea59835b514d9057/setuptools-75.1.0-py3-none-any.whl (1.2 MB)
                  Collecting cython>=0.25
                    Downloading https://mirrors.aliyun.com/pypi/packages/b2/52/eda119f98071ccde04a9a1c9c9a18fd6def025651c9d0cd01ad51d0dba36/Cython-3.0.11-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.6 MB)
                       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.6/3.6 MB 1.3 MB/s eta 0:00:00
                  ERROR: Ignored the following versions that require a different python version: 1.25.0 Requires-Python >=3.9; 1.25.1 Requires-Python >=3.9; 1.25.2 Requires-Python >=3.9; 1.26.0 Requires-Python <3.13,>=3.9; 1.26.1 Requires-Python <3.13,>=3.9; 1.26.2 Requires-Python >=3.9; 1.26.3 Requires-Python >=3.9; 1.26.4 Requires-Python >=3.9; 2.0.0 Requires-Python >=3.9; 2.0.1 Requires-Python >=3.9; 2.0.2 Requires-Python >=3.9; 2.1.0 Requires-Python >=3.10; 2.1.0rc1 Requires-Python >=3.10; 2.1.1 Requires-Python >=3.10; 2.1.2 Requires-Python >=3.10
                  ERROR: Could not find a version that satisfies the requirement numpy<3.0.0,>=2.0.0 (from versions: 1.3.0, 1.4.1, 1.5.0, 1.5.1, 1.6.0, 1.6.1, 1.6.2, 1.7.0, 1.7.1, 1.7.2, 1.8.0, 1.8.1, 1.8.2, 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.10.0.post2, 1.10.1, 1.10.2, 1.10.4, 1.11.0, 1.11.1, 1.11.2, 1.11.3, 1.12.0, 1.12.1, 1.13.0, 1.13.1, 1.13.3, 1.14.0, 1.14.1, 1.14.2, 1.14.3, 1.14.4, 1.14.5, 1.14.6, 1.15.0, 1.15.1, 1.15.2, 1.15.3, 1.15.4, 1.16.0, 1.16.1, 1.16.2, 1.16.3, 1.16.4, 1.16.5, 1.16.6, 1.17.0, 1.17.1, 1.17.2, 1.17.3, 1.17.4, 1.17.5, 1.18.0, 1.18.1, 1.18.2, 1.18.3, 1.18.4, 1.18.5, 1.19.0, 1.19.1, 1.19.2, 1.19.3, 1.19.4, 1.19.5, 1.20.0, 1.20.1, 1.20.2, 1.20.3, 1.21.0, 1.21.1, 1.21.2, 1.21.3, 1.21.4, 1.21.5, 1.21.6, 1.22.0, 1.22.1, 1.22.2, 1.22.3, 1.22.4, 1.23.0, 1.23.1, 1.23.2, 1.23.3, 1.23.4, 1.23.5, 1.24.0, 1.24.1, 1.24.2, 1.24.3, 1.24.4)
                  ERROR: No matching distribution found for numpy<3.0.0,>=2.0.0
                  [end of output]
      
              note: This error originates from a subprocess, and is likely not a problem with pip.
            error: subprocess-exited-with-error
      
            × pip subprocess to install build dependencies did not run successfully.
            │ exit code: 1
            ╰─> See above for output.
      
            note: This error originates from a subprocess, and is likely not a problem with pip.
            [end of output]
      
        note: This error originates from a subprocess, and is likely not a problem with pip.
      error: subprocess-exited-with-error
      
      × pip subprocess to install build dependencies did not run successfully.
      │ exit code: 1
      ╰─> See above for output.
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× pip subprocess to install build dependencies did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```
After some investigation, I found the reason is pip install the latest version(3.8.2) of spacy by defaut. I checked the wheels list , it only supports python 3.9+.  The latest version which supports `python 3.8` is `spacy 3.7.5`. 