### PR TITLE
Fix an error related with device being a string

### DIFF
--- a/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
+++ b/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
@@ -318,7 +318,7 @@ class PyramidDiTForVideoGeneration:
         cpu_offloading: bool = False, # If true, reload device will be cuda.
         inference_multigpu: bool = False,
     ):
-        device = self.device if not cpu_offloading else "cuda"
+        device = self.device if not cpu_offloading else torch.device("cuda")
         dtype = self.dtype
         if cpu_offloading:
             # skip caring about the text encoder here as its about to be used anyways.
@@ -520,7 +520,7 @@ class PyramidDiTForVideoGeneration:
         cpu_offloading: bool = False, # If true, reload device will be cuda.
         inference_multigpu: bool = False,
     ):
-        device = self.device if not cpu_offloading else "cuda"
+        device = self.device if not cpu_offloading else torch.device("cuda")
         dtype = self.dtype
         if cpu_offloading:
             # skip caring about the text encoder here as its about to be used anyways.


### PR DESCRIPTION
## What

Fix the error:
  File "/usr/local/lib/python3.8/dist-packages/diffusers/utils/torch_utils.py", line 58, in randn_tensor
    if gen_device_type != device.type and gen_device_type == "cpu":
AttributeError: 'str' object has no attribute 'type'

## Why
I think the device is suppose to be torch.device instead of just "cuda"

## Steps to reproduction

Just pass a generator to the pipeline:

```python
generator  = torch.Generator(device="cuda").manual_seed(seed)
model.generate(generator=generator, **other_args)
```
