### PR TITLE
Ensure the image being at the vae device and having same type

### DIFF
--- a/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
+++ b/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
@@ -412,7 +412,7 @@ class PyramidDiTForVideoGeneration:
             transforms.Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5)),
         ])
         input_image_tensor = image_transform(input_image).unsqueeze(0).unsqueeze(2)   # [b c 1 h w]
-        input_image_latent = (self.vae.encode(input_image_tensor.to(device)).latent_dist.sample() - self.vae_shift_factor) * self.vae_scale_factor  # [b c 1 h w]
+        input_image_latent = (self.vae.encode(input_image_tensor.to(self.vae.device, dtype=self.vae.dtype)).latent_dist.sample() - self.vae_shift_factor) * self.vae_scale_factor  # [b c 1 h w]
 
         if is_sequence_parallel_initialized():
             # sync the image latent across multiple GPUs


### PR DESCRIPTION
## What
When we do a CPU offload the transformer goes to CPU, then de pipeline device goes to CPU as well as it's returned by a property. It causes an error because we send the image to the CPU, while the VAE goes to GPU.

## Why
The image should be at the VAE device and I think it should have the same dtype.

## Steps to reproduce

Image2Video with CPU Offload.

