### PR TITLE
Add support to sequential cpu offload 8GB VRAM maybe less

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,14 @@ model = PyramidDiTForVideoGeneration(
     model_variant='diffusion_transformer_768p',     # 'diffusion_transformer_384p'
 )
 
-model.vae.to("cuda")
-model.dit.to("cuda")
-model.text_encoder.to("cuda")
+
 model.vae.enable_tiling()
+# model.vae.to("cuda")
+# model.dit.to("cuda")
+# model.text_encoder.to("cuda")
+
+# if you're not using sequential offloading bellow uncomment the lines above ^
+model.enable_sequential_cpu_offload()
 ```
 
 Then, you can try text-to-video generation on your own prompts:

--- a/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
+++ b/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 from torchvision import transforms
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Union
-from accelerate import Accelerator
+from accelerate import Accelerator, cpu_offload
 from diffusion_schedulers import PyramidFlowMatchEulerDiscreteScheduler
 from video_vae.modeling_causal_vae import CausalVideoVAE
 


### PR DESCRIPTION
## What
Use even less memory to run it.

## Why
To help people with 8GB VRAM GPU

## Description

Add support to sequential CPU offloading.

* Take longer, however runs on with very low VRAM and way faster than only using CPU.
* Keeps the previous logic of offloading.

# For the reviewer

Generate a text to video and a image to video to validate (I moved the logic from a personal project to support this one here).

How to use:
```python
model = PyramidDiTForVideoGeneration(
    'PATH',                                         # The downloaded checkpoint dir
    model_dtype,
    model_variant='diffusion_transformer_768p',     # 'diffusion_transformer_384p'
)


model.vae.enable_tiling()
model.enable_sequential_cpu_offload()
```

![image](https://github.com/user-attachments/assets/f67a8a08-c32a-485c-8f72-b77e547ea02f)

