### PR TITLE
Progress in app + sys mem fallback fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,11 +151,15 @@ def resize_crop_image(img: PIL.Image.Image, tgt_width, tgt_height):
     return img
 
 # Function to generate text-to-video
-def generate_text_to_video(prompt, temp, guidance_scale, video_guidance_scale, resolution):
+def generate_text_to_video(prompt, temp, guidance_scale, video_guidance_scale, resolution, progress=gr.Progress()):
+    progress(0, desc="Loading model")
     print("[DEBUG] generate_text_to_video called.")
     variant = '768p' if resolution == "768p" else '384p'
     height = height_high if resolution == "768p" else height_low
     width = width_high if resolution == "768p" else width_low
+
+    def progress_callback(i, m):
+        progress(i/m)
 
     # Initialize model based on user options using cached function
     try:
@@ -179,6 +183,7 @@ def generate_text_to_video(prompt, temp, guidance_scale, video_guidance_scale, r
                 output_type="pil",
                 cpu_offloading=cpu_offloading,
                 save_memory=True,
+                callback=progress_callback,
             )
         print("[INFO] Text-to-video generation completed.")
     except Exception as e:
@@ -195,7 +200,7 @@ def generate_text_to_video(prompt, temp, guidance_scale, video_guidance_scale, r
     return video_path
 
 # Function to generate image-to-video
-def generate_image_to_video(image, prompt, temp, video_guidance_scale, resolution):
+def generate_image_to_video(image, prompt, temp, video_guidance_scale, resolution, progress=gr.Progress()):
     print("[DEBUG] generate_image_to_video called.")
     variant = '768p' if resolution == "768p" else '384p'
     height = height_high if resolution == "768p" else height_low
@@ -207,6 +212,9 @@ def generate_image_to_video(image, prompt, temp, video_guidance_scale, resolutio
     except Exception as e:
         print(f"[ERROR] Error processing image: {e}")
         return f"Error processing image: {e}"
+
+    def progress_callback(i, m):
+        progress(i/m)
 
     # Initialize model based on user options using cached function
     try:
@@ -227,6 +235,7 @@ def generate_image_to_video(image, prompt, temp, video_guidance_scale, resolutio
                 output_type="pil",
                 cpu_offloading=cpu_offloading,
                 save_memory=True,
+                callback=progress_callback,
             )
         print("[INFO] Image-to-video generation completed.")
     except Exception as e:

--- a/app.py
+++ b/app.py
@@ -201,6 +201,7 @@ def generate_text_to_video(prompt, temp, guidance_scale, video_guidance_scale, r
 
 # Function to generate image-to-video
 def generate_image_to_video(image, prompt, temp, video_guidance_scale, resolution, progress=gr.Progress()):
+    progress(0, desc="Loading model")
     print("[DEBUG] generate_image_to_video called.")
     variant = '768p' if resolution == "768p" else '384p'
     height = height_high if resolution == "768p" else height_low


### PR DESCRIPTION
This adds a progress bar in the app as well as adding a fix for flooding into system memory.

Previously, cache "stepped up" as the process continued, which de-allocated when it reached the max amount. When sys mem fallback is enabled, the ceiling is raised so it doesn't de-allocate and instead enters system memory.

Step up effect is shown here:
![Screenshot from 2024-10-12 20-33-23](https://github.com/user-attachments/assets/e94a108c-8535-49a0-9148-c70206c15778)

This fix collects cache after each step, stopping this effect:
![Screenshot from 2024-10-12 20-43-57](https://github.com/user-attachments/assets/1102aa82-26ea-4e32-ac21-04e3c0fd5f6a)

Also, added a progress bar and pipeline callback:
![Screenshot from 2024-10-12 20-44-06](https://github.com/user-attachments/assets/265115cd-0404-4ac2-a902-cf7ebe6c343a)
