### PR TITLE
Add missing verification in cpu sequential offload

### DIFF
--- a/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
+++ b/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
@@ -504,7 +504,8 @@ class PyramidDiTForVideoGeneration:
             image = generated_latents
         else:
             if cpu_offloading:
-                self.dit.to("cpu")
+                if not self.sequential_offload_enabled:
+                    self.dit.to("cpu")
                 self.vae.to("cuda")
                 torch.cuda.empty_cache()
             image = self.decode_latent(generated_latents, save_memory=save_memory, inference_multigpu=inference_multigpu)


### PR DESCRIPTION
## What
Add verification before moving dit across devices.

## Why
It's not suppose to move the transformer between devices when sequential cpu offload is enabled.

## Description
It was missing one verification. Sorry for that.