### PR TITLE
Use MPS backend on Apple Silicon devices if it's available. (Updated)

### DIFF
--- a/diffusion_schedulers/scheduling_flow_matching.py
+++ b/diffusion_schedulers/scheduling_flow_matching.py
@@ -176,7 +176,7 @@ class PyramidFlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
     def _sigma_to_t(self, sigma):
         return sigma * self.config.num_train_timesteps
 
-    def set_timesteps(self, num_inference_steps: int, stage_index: int, device: Union[str, torch.device] = None):
+    def set_timesteps(self, num_inference_steps: int, stage_index: int, device: Union[str, torch.device] = None, dtype: torch.dtype = None):
         """
             Setting the timesteps and sigmas for each stage 
         """
@@ -191,7 +191,7 @@ class PyramidFlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         timesteps = np.linspace(
             timestep_max, timestep_min, num_inference_steps,
         )
-        self.timesteps = torch.from_numpy(timesteps).to(device=device)
+        self.timesteps = torch.from_numpy(timesteps).to(device=device, dtype=dtype)
 
         stage_sigmas = self.sigmas_per_stage[stage_index]
         sigma_max = stage_sigmas[0].item()
@@ -200,7 +200,7 @@ class PyramidFlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         ratios = np.linspace(
             sigma_max, sigma_min, num_inference_steps
         )
-        sigmas = torch.from_numpy(ratios).to(device=device)
+        sigmas = torch.from_numpy(ratios).to(device=device, dtype=dtype)
         self.sigmas = torch.cat([sigmas, torch.zeros(1, device=sigmas.device)])
 
         self._step_index = None

--- a/pyramid_dit/modeling_pyramid_mmdit.py
+++ b/pyramid_dit/modeling_pyramid_mmdit.py
@@ -28,7 +28,7 @@ from IPython import embed
 def rope(pos: torch.Tensor, dim: int, theta: int) -> torch.Tensor:
     assert dim % 2 == 0, "The dimension must be even."
 
-    scale = torch.arange(0, dim, 2, dtype=torch.float64, device=pos.device) / dim
+    scale = torch.arange(0, dim, 2, dtype=pos.dtype, device=pos.device) / dim
     omega = 1.0 / (theta**scale)
 
     batch_size, seq_length = pos.shape

--- a/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
+++ b/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
@@ -248,7 +248,7 @@ class PyramidDiTForVideoGeneration:
         intermed_latents = []
 
         for i_s in range(len(stages)):
-            self.scheduler.set_timesteps(num_inference_steps[i_s], i_s, device=device)
+            self.scheduler.set_timesteps(num_inference_steps[i_s], i_s, device=device, dtype=dtype)
             timesteps = self.scheduler.timesteps
 
             if i_s > 0:

--- a/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
+++ b/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
@@ -337,7 +337,7 @@ class PyramidDiTForVideoGeneration:
         if self.sequential_offload_enabled and not cpu_offloading:
             print("Warning: overriding cpu_offloading set to false, as it's needed for sequential cpu offload")
             cpu_offloading=True
-        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("mps") if torch.mps.is_available() else torch.device("cpu")
+        device = self.device
         dtype = self.dtype
         if cpu_offloading:
             # skip caring about the text encoder here as its about to be used anyways.
@@ -557,7 +557,7 @@ class PyramidDiTForVideoGeneration:
         if self.sequential_offload_enabled and not cpu_offloading:
             print("Warning: overriding cpu_offloading set to false, as it's needed for sequential cpu offload")
             cpu_offloading=True
-        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("mps") if torch.mps.is_available() else torch.device("cpu")
+        device = self.device
         dtype = self.dtype
         if cpu_offloading:
             # skip caring about the text encoder here as its about to be used anyways.

--- a/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
+++ b/pyramid_dit/pyramid_dit_for_video_gen_pipeline.py
@@ -147,8 +147,9 @@ class PyramidDiTForVideoGeneration:
         cpu_offload(model, device, offload_buffers=offload_buffers)
     
     def enable_sequential_cpu_offload(self):
-        self._enable_sequential_cpu_offload(self.text_encoder)
-        self._enable_sequential_cpu_offload(self.dit)
+        if torch.cuda.is_available():
+            self._enable_sequential_cpu_offload(self.text_encoder)
+            self._enable_sequential_cpu_offload(self.dit)
 
     def load_checkpoint(self, checkpoint_path, model_key='model', **kwargs):
         checkpoint = torch.load(checkpoint_path, map_location='cpu')
@@ -336,7 +337,7 @@ class PyramidDiTForVideoGeneration:
         if self.sequential_offload_enabled and not cpu_offloading:
             print("Warning: overriding cpu_offloading set to false, as it's needed for sequential cpu offload")
             cpu_offloading=True
-        device = self.device if not cpu_offloading else torch.device("cuda")
+        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("mps") if torch.mps.is_available() else torch.device("cpu")
         dtype = self.dtype
         if cpu_offloading:
             # skip caring about the text encoder here as its about to be used anyways.
@@ -452,8 +453,11 @@ class PyramidDiTForVideoGeneration:
         
         for unit_index in tqdm(range(1, num_units)):
             gc.collect()
-            torch.cuda.empty_cache()
-            
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            elif torch.mps.is_available():
+                torch.mps.empty_cache()
+
             if callback:
                 callback(unit_index, num_units)
         
@@ -553,7 +557,7 @@ class PyramidDiTForVideoGeneration:
         if self.sequential_offload_enabled and not cpu_offloading:
             print("Warning: overriding cpu_offloading set to false, as it's needed for sequential cpu offload")
             cpu_offloading=True
-        device = self.device if not cpu_offloading else torch.device("cuda")
+        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("mps") if torch.mps.is_available() else torch.device("cpu")
         dtype = self.dtype
         if cpu_offloading:
             # skip caring about the text encoder here as its about to be used anyways.
@@ -650,8 +654,11 @@ class PyramidDiTForVideoGeneration:
 
         for unit_index in tqdm(range(num_units)):
             gc.collect()
-            torch.cuda.empty_cache()
-            
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            elif torch.mps.is_available():
+                torch.mps.empty_cache()
+
             if callback:
                 callback(unit_index, num_units)
             

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
+--extra-index-url https://download.pytorch.org/whl/nightly/cpu
 wheel
-torch==2.1.2
-torchvision==0.16.2
+torch
+torchvision
 transformers==4.39.3
 accelerate==0.30.0
 diffusers>=0.30.1
-numpy==1.24.4
+numpy==1.26.4
 einops
 ftfy
 ipython

--- a/video_vae/modeling_causal_vae.py
+++ b/video_vae/modeling_causal_vae.py
@@ -361,6 +361,8 @@ class CausalVideoVAE(ModelMixin, ConfigMixin):
 
         dec_list = []
         for idx, frames in enumerate(frame_list):
+            if torch.mps.is_available():
+                torch.mps.empty_cache()
             if idx == 0:
                 z_h = self.post_quant_conv(frames, is_init_image=True, temporal_chunk=True)
                 dec = self.decoder(z_h, is_init_image=True, temporal_chunk=True)


### PR DESCRIPTION
This is slighly updated version of #108. Since #108 was accidentally merged and reverted and I can't no longer update with new changes it, this Pull Request is newerly created.

For MacBook users who want to try, follow next steps:
1. Clone jy0205/Pyramid-Flow and apply this Pull Request.
2. Install Python 3.10 by using Homebrew, for example, `bew install python@3.10`
3. Use virtualenv to install dependencies, for example, `python3.10 -m venv .venv && .venv/bin/pip3 install -r requirements.txt`
4. Install extra dependency, `gradio` for `app.py`, like `.venv/bin/pip3 install gradio`
5. Run `.venv/bin/python3 app.py`, then open `http://127.0.0.1:7860/`.

To generate video, try minimum settings. It takes loooong time anyways on MacBook (10 minuts for 3 seconds video, for example, well, it's still remarkable, tho!)
- Model resolution: 384p
- Duration 2 or 3

---

**Problems**

For the inference, it works faster by using MPS backend on Apple Silicon devices but it's not enabled by default and requires some modification to the code, which only considering CUDA availability.

**Solution**

Use MPS backend if it's available.

- Use compatible dtype.
- Enable CPU offloading only if CUDA backend is used (disabled for MPS backend, which is unnecesary because of unified memory.)
- Use the nightly pytorch, which is required to address VAE issue.

**NOTE:** This patch is not taking trainig account at all, only for inference. I tried to make it works as well as CUDA with this patch, but because of for example, dependencies update, which may not be preferred, therefore I don't expect that this Pull Request is mergable into `main` for now. However, anyways posting here because I think it’s worth to have it for those who want to try inferencing easily on such as thier MacBook Pro.