### PR TITLE
Update app.py to remove public share by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -353,4 +353,4 @@ Pyramid Flow is a training-efficient **Autoregressive Video Generation** model b
     )
 
 # Launch Gradio app
-demo.launch(share=True)
+demo.launch(share=False)


### PR DESCRIPTION
Changed the launch argument "share" to false. 

Temporary fix for default public share.