### PR TITLE
Change gradio launch to stop being public by default.

### DIFF
--- a/app.py
+++ b/app.py
@@ -353,4 +353,4 @@ Pyramid Flow is a training-efficient **Autoregressive Video Generation** model b
     )
 
 # Launch Gradio app
-demo.launch(share=True)
+demo.launch(share=False)

--- a/app_multigpu.py
+++ b/app_multigpu.py
@@ -140,4 +140,4 @@ Pyramid Flow is a training-efficient **Autoregressive Video Generation** model b
     )
 
 # Launch Gradio app
-demo.launch(share=True)
+demo.launch(share=False)


### PR DESCRIPTION
I changed the launch argument "share" to false to stop creating a public link by default, since it has been requested and is a security risk.

Temporary fix until a user friendly way is implemented. If that's even needed.